### PR TITLE
Harden URL scheme check

### DIFF
--- a/Classes/Middleware/AlwaysForceHttps.php
+++ b/Classes/Middleware/AlwaysForceHttps.php
@@ -16,9 +16,9 @@ class AlwaysForceHttps implements MiddlewareInterface
     {
         if (!$request->getAttribute('normalizedParams')->isHttps()) {
             $requestedUrl = $request->getAttribute('normalizedParams')->getRequestUrl();
-            if(str_contains($requestedUrl, "http://")) {
-                $requestUrl = str_replace("http://", "https://", $requestedUrl
-                );
+
+            if (str_starts_with($requestedUrl, 'http://')) {
+                $requestUrl = str_replace('http://', 'https://', $requestedUrl);
 
                 return new RedirectResponse($requestUrl);
             }


### PR DESCRIPTION
We should check if the URL starts with "http://", not if it appears anywhere in the URL.